### PR TITLE
Prevent knob change event to run in non GUI mode.

### DIFF
--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -271,6 +271,8 @@ def cryptomatte_create_gizmo():
 
 
 def cryptomatte_knob_changed_event(node = None, knob = None):
+    if not nuke.GUI:  # Prevent event when not in GUI mode
+        return
     if knob.name() == "inputChange" or knob.name() == "cryptoLayer" or knob.name() == "cryptoLayerLock":
         cinfo = CryptomatteInfo(node)
         _update_cryptomatte_gizmo(node, cinfo)


### PR DESCRIPTION
When rendering on the farm we got errors with node.metadata() returning None.
The knob change event seem to be called at knob creation on load of the setup and not only when the cryptomatte tab panel is open like explained in the documentation of nuke.