### PR TITLE
fusion cryptomatte render farm crash fix

### DIFF
--- a/fusion/cryptomatte.fuse
+++ b/fusion/cryptomatte.fuse
@@ -367,11 +367,11 @@ end
 -- ============================================================================
 -- cryptomatte fuse
 -- ============================================================================
-FuRegisterClass("Cryptomatte", CT_Tool, {
-    REGS_Name = "Cryptomatte",
-    REGS_Category = "Cryptomatte",
-    REGS_OpIconString = "Cryptomatte",
-    REGS_OpDescription = "Cryptomatte",
+FuRegisterClass("Cryptomatte2", CT_Tool, {
+    REGS_Name = "Cryptomatte2",
+    REGS_Category = "Cryptomatte2",
+    REGS_OpIconString = "Cryptomatte2",
+    REGS_OpDescription = "Cryptomatte2",
     REG_NoMotionBlurCtrls = true,
     REG_NoBlendCtrls = true,
     REG_OpNoMask = true
@@ -751,16 +751,20 @@ function Process(req)
         -- get loader connected to fuse
         local fusion = Fusion()
         local comp = fusion.CurrentComp
-        local tool = comp:FindTool(self.Name)
-        local loader = get_input_loader(tool)
-        -- get all channels listed in the loader's first channel slot
-        local all_channels = get_all_channels_from_loader(loader)
-        -- get all unique ranks from the channel list
-        local ranks = get_all_ranks_from_channels(all_channels)
-        -- fill in all the remaining slots correctly
-        set_channel_slots(loader, ranks)
-        -- reset callback
-        InImageConnectCB:SetSource(Number(0), 0, 0)
+        -- check if comp can be retrieved from fusion object, when rendering a comp with fusion render or console node
+        -- the comp will be nil, so skip this force update loader channel slots
+        if comp then
+            local tool = comp:FindTool(self.Name)
+            local loader = get_input_loader(tool)
+            -- get all channels listed in the loader's first channel slot
+            local all_channels = get_all_channels_from_loader(loader)
+            -- get all unique ranks from the channel list
+            local ranks = get_all_ranks_from_channels(all_channels)
+            -- fill in all the remaining slots correctly
+            set_channel_slots(loader, ranks)
+            -- reset callback
+            InImageConnectCB:SetSource(Number(0), 0, 0)
+        end
     end
 
     -- extract all cryptomatte metadata

--- a/fusion/cryptomatte.fuse
+++ b/fusion/cryptomatte.fuse
@@ -356,22 +356,17 @@ function get_all_rank_images(input_image)
     local crypto_image_00 = input_image:ChannelOpOf("Copy", nil, { R = "bg.Z", G = "bg.Coverage", B = "bg.U", A = "bg.V" })
     local crypto_image_01 = input_image:ChannelOpOf("Copy", nil, { R = "bg.NX", G = "bg.NY", B = "bg.NZ", A = "bg.VectX" })
     local crypto_image_02 = input_image:ChannelOpOf("Copy", nil, { R = "bg.VectY", G = "bg.BackVectX", B = "bg.BackVectY", A = "bg.PositionX" })
-    return {
-        crypto_image_std,
-        crypto_image_00,
-        crypto_image_01,
-        crypto_image_02
-    }
+    return { crypto_image_std, crypto_image_00, crypto_image_01, crypto_image_02 }
 end
 
 -- ============================================================================
 -- cryptomatte fuse
 -- ============================================================================
-FuRegisterClass("Cryptomatte2", CT_Tool, {
-    REGS_Name = "Cryptomatte2",
-    REGS_Category = "Cryptomatte2",
-    REGS_OpIconString = "Cryptomatte2",
-    REGS_OpDescription = "Cryptomatte2",
+FuRegisterClass("Cryptomatte", CT_Tool, {
+    REGS_Name = "Cryptomatte",
+    REGS_Category = "Cryptomatte",
+    REGS_OpIconString = "Cryptomatte",
+    REGS_OpDescription = "Cryptomatte",
     REG_NoMotionBlurCtrls = true,
     REG_NoBlendCtrls = true,
     REG_OpNoMask = true
@@ -402,7 +397,6 @@ function Create()
         LINKID_DataType = "Image",
         LINK_Main = 1
     })
-
 
     -- ========================================================================
     -- locator


### PR DESCRIPTION
Inhouse we started using cryptomatte for fusion and discovered a problem when rendering on the farm with the FusionRenderConsole. The console was trying to render a comp with a cryptomatte fuse and crashed when trying to render the fuse's result out. The error log stated that the local var comp (ex line 753) could not be used because it was a nil value. When debugging this, I realised the Fusion() object always returns an actual object, console or not, but when trying to get the current comp property, it crashed when in batch / console mode. This commit has a check implemented to see if the comp retrieved is valid before actually force updating the loader's channel slots. Small fix for quite a big problem.