### PR TITLE
Reworked _identify_channels function in nuke

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ Decoders:
 * Vladimir Koylazov
 * Peter Loveday
 * Andrew Hazelden
+* Jens Lindgren

--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -25,6 +25,7 @@ CRYPTO_METADATA_DEFAULT_PREFIX = CRYPTO_METADATA_LEGAL_PREFIX[1]
 
 import nuke
 import struct
+import re
 
 def setup_cryptomatte_ui():
     if nuke.GUI:
@@ -217,7 +218,7 @@ class CryptomatteInfo(object):
 
     def _identify_channels(self, name):
         """from a name like "cryptoObject", 
-        gets sorted channels, such as cryptoObject, cryptoObject00, cryptoObject01
+        gets sorted channels, such as cryptoObject00, cryptoObject01, cryptoObject02
         """
 
         channel_list = []
@@ -228,15 +229,13 @@ class CryptomatteInfo(object):
             # nuke_node might a read node
             channel_list = self.nuke_node.channels()
 
-        relevant_channels = [x for x in channel_list if x.startswith(name)]
+        # regex for "cryptoObject" + digits + ending with .red or .r
+        channel_regex = re.compile(r'({name}\d+)\.(?:red|r)$'.format(name=name))
         pure_channels = []
-        for channel in relevant_channels:
-            suffix = ".red"
-            if not channel.endswith(suffix):
-                continue
-            pure_channel = channel[:-len(suffix)]
-            if pure_channel != name: # ignore the human readable ones
-                pure_channels.append(pure_channel)
+        for channel in channel_list:
+            match = channel_regex.match(channel)
+            if match:
+                pure_channels.append(match.group(1))
 
         return sorted(pure_channels)
 


### PR DESCRIPTION
This is a partial rewrite of the _identify_channels function in the Nuke plugin.
I have switched out the old logic of multiple if statements for a regex match object that does most of the work.
I don't know if it's necessary but the new version can also detect channels ending in just .r as well as .red.
Test suite passed without any problems.

This fixes #85 as well.