### PR TITLE
fix decrypto inside Groups or Live Groups on btn

### DIFF
--- a/nuke/cryptomatte_utilities.py
+++ b/nuke/cryptomatte_utilities.py
@@ -1147,6 +1147,11 @@ def decryptomatte_selected(ask=False):
 
 
 def decryptomatte_button(node):
+    if "." in nuke.thisNode().fullName():
+        parent_name = ".".join(nuke.thisNode().fullName().split(".")[:-1])
+        with nuke.toNode(parent_name):
+            decryptomatte_nodes([node], False)
+            return
     with nuke.root():
         decryptomatte_nodes([node], False)
 


### PR DESCRIPTION
I tested this in Nuke 10 to 12 and inside LiveGroups. node.parent() does not exist in older Versions of nuke. So I went the "ugly" way, that I know, maybe there is a better way to achieve the same ?
Open for improvements.

All the best
Johannes